### PR TITLE
Add CareOps healthcare mode and marketing experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,18 @@ Let your customers extend your product's functionality without learning your API
 
 ### 🎯 Key Features
 
-🤖 **AI Code Generation** – Phase-wise development with intelligent error correction  
-⚡ **Live Previews** – App previews running in sandboxed containers  
-💬 **Interactive Chat** – Guide development through natural conversation  
-📱 **Modern Stack** – Generates React + TypeScript + Tailwind apps  
-🚀 **One-Click Deploy** – Deploy generated apps to Workers for Platforms  
-📦 **GitHub Integration** – Export code directly to your repositories  
+🤖 **AI Code Generation** – Phase-wise development with intelligent error correction
+⚡ **Live Previews** – App previews running in sandboxed containers
+💬 **Interactive Chat** – Guide development through natural conversation
+📱 **Modern Stack** – Generates React + TypeScript + Tailwind apps
+🚀 **One-Click Deploy** – Deploy generated apps to Workers for Platforms
+📦 **GitHub Integration** – Export code directly to your repositories
+💰 **Revenue Mode** – Purpose-built agent orchestration that produces monetization-ready apps with pricing labs, funnel analytics, lifecycle automation, and CRM/billing integrations out of the box
+🩺 **CareOps Mode** – Healthcare-specific directives that bake in HIPAA compliance, clinical workflows, FHIR integrations, and reimbursable program design for digital care offerings
+
+👉 Explore the [Revenue Mode playbook](docs/revenue-mode.md) to see how to turn VibeSDK into a high-velocity revenue platform.
+
+🩺 Dive into the [CareOps Mode playbook](docs/healthcare-mode.md) to package regulated healthcare experiences with monetization hooks.
 
 ### 🏗️ Built on Cloudflare's Platform
 

--- a/docs/healthcare-mode.md
+++ b/docs/healthcare-mode.md
@@ -1,0 +1,39 @@
+# CareOps Mode Playbook
+
+CareOps Mode extends Orange Build into a healthcare-specific application factory. Every generated experience assumes it will touch protected health information (PHI), orchestrate care teams, and unlock reimbursable service lines. Use this playbook to package, position, and monetize turnkey digital health solutions.
+
+## 1. Product Thesis
+- **Clinical-grade blueprints** — Automatically inject HIPAA guardrails, consent flows, audit trails, and role-based permissions into the generated plan.
+- **Connected ecosystem** — Document data contracts for HL7/FHIR exchanges, telehealth platforms, e-prescribing, claims clearinghouses, and secure messaging tools.
+- **End-to-end care journeys** — Map intake, triage, scheduling, virtual visits, care-plan management, and follow-ups with multilingual accessibility guidance baked in.
+- **Revenue-aligned** — Highlight reimbursable RPM/CCM programs, employer/payer portals, membership tiers, and concierge upsell flows.
+
+## 2. Core Deliverables
+1. **Blueprint Directive** – The planning agent enforces clinical compliance, safety checklists, and monetization strategy for care services.
+2. **Template Selection Logic** – Prompts automatically route to secure portals, operational dashboards, or workflow templates when healthcare signals are detected.
+3. **Healthcare Prompt Pack** – Sample prompts demonstrate high-value CareOps scenarios (virtual clinics, population health, CareOps marketplaces).
+4. **Dynamic Home Experience** – The landing page reframes Orange Build as a CareOps launcher, exposing value propositions for clinicians, operators, and revenue teams.
+5. **Documentation Trail** – This playbook plus README highlights communicate the offer to stakeholders and buyers.
+
+## 3. Monetization Strategies
+- **Subscription Licensing** – Charge per clinic, provider, or virtual program with usage-based tiers tied to patient panels or active care plans.
+- **Implementation & Compliance Services** – Offer white-glove configuration, security risk assessments, and HIPAA readiness packages as billable add-ons.
+- **Integration Packs** – Sell pre-built connectors for major EHRs (Epic, Athenahealth, Cerner), telehealth suites, and billing systems.
+- **Marketplace Revenue Share** – Enable specialists to list digital care pathways; collect a platform fee on subscription, visit, or reimbursement flows.
+- **Outcome Analytics Upsells** – Package predictive insights (readmission risk, population stratification) as premium analytics modules.
+
+## 4. Go-to-Market Motions
+- **Pilot with Virtual-First Clinics** – Target digitally native care providers that need HIPAA-ready front doors and remote monitoring workflows.
+- **Partner with MSOs & Health Systems** – Co-market templated service lines (e.g., cardiology RPM, behavioral health teletherapy) bundled with integration services.
+- **Sell to Employer Health Vendors** – Position CareOps Mode as a rapid way to spin up white-labeled care programs for benefit administrators.
+- **Channel Through RevOps Agencies** – Equip healthcare-focused agencies with packaged templates plus revenue-sharing for co-delivery.
+- **Leverage Compliance Proof Points** – Publish security architecture diagrams, third-party attestations, and audit logging examples to accelerate procurement.
+
+## 5. Success Metrics
+- Average time from prompt to deployable CareOps experience.
+- Number of reimbursable programs launched and associated PMPM revenue.
+- Integration attach rate (EHR, telehealth, claims) per customer.
+- Net promoter score from clinicians and care coordinators using generated tools.
+- Monthly recurring revenue from CareOps subscriptions and services.
+
+Activate CareOps Mode when you need to turn regulated healthcare ideas into operational, revenue-generating digital care offerings in days instead of quarters.

--- a/docs/projectreport.md
+++ b/docs/projectreport.md
@@ -44,7 +44,7 @@ Orange Build v2.0 represents a complete architectural modernization, migrating f
 
 ### III. AI Agent Orchestration System
 
-Orange Build employs a sophisticated multi-agent architecture with two operational modes:
+Orange Build employs a sophisticated multi-agent architecture with three operational modes:
 
 #### Agent Operational Modes:
 
@@ -59,6 +59,18 @@ Orange Build employs a sophisticated multi-agent architecture with two operation
 - Dynamic workflow adaptation based on project context and user interactions
 - Advanced conversational capabilities with natural language processing
 - Optimal for iterative development and user-guided refinements
+
+**3. Revenue Mode (`agentMode: 'revenue'`)**
+- Extends deterministic generation with monetization-specific planning directives
+- Injects pricing labs, lifecycle automation, analytics instrumentation, and GTM experiments directly into blueprints
+- Prioritizes integrations with CRM, billing, and product analytics systems to accelerate revenue ops deployments
+- Ideal for growth, RevOps, and agency teams packaging repeatable revenue playbooks
+
+**4. CareOps Mode (`agentMode: 'healthcare'`)**
+- Adds a healthcare-specific directive that enforces HIPAA compliance, consent capture, audit trails, and role-based controls.
+- Guides blueprints to outline HL7/FHIR integrations, telehealth experiences, claims/billing handoffs, and safety checklists.
+- Highlights reimbursable RPM/CCM programs, employer/payer portals, and concierge add-ons to unlock healthcare revenue streams.
+- Tailors the home experience and prompt packs toward clinics, MSOs, and digital health startups needing operational rigor.
 
 #### Core Agent Classes:
 

--- a/docs/revenue-mode.md
+++ b/docs/revenue-mode.md
@@ -1,0 +1,47 @@
+# Revenue Mode Playbook
+
+## Vision
+Revenue Mode transforms VibeSDK into a monetization-first application generator. Every build becomes a packaged revenue engine that ships with pricing strategy, conversion funnels, lifecycle automation, and analytics instrumentation ready for activation.
+
+## Target Segments
+- **Growth & Monetization Teams** at PLG SaaS companies that need rapid experimentation.
+- **Revenue Operations Leaders** who require unified tooling for pricing, sales-assisted flows, and customer success.
+- **Agencies & Fractional CROs** productizing their playbooks into repeatable micro-apps for clients.
+
+## Core Differentiators
+1. **Monetization-Ready Blueprints** – Pricing labs, ROI calculators, upsell workflows, and compliance messaging are automatically embedded into every plan.
+2. **Lifecycle Intelligence** – Generated apps include revenue dashboards, funnel analytics, and KPI guardrails (CAC, LTV, expansion, churn) with instrumentation instructions.
+3. **Enterprise Integrations** – CRM, billing, product analytics, and marketing automation touchpoints are mapped with explicit data contracts.
+4. **Experimentation Architecture** – Toggle paywalls, localization, packaging variations, and hero copy tests from the admin console with minimal code edits.
+
+## Business Model
+- **Platform Licensing:** Offer paid tiers for organizations that need custom domains, persistent storage, and governance controls for multi-team usage.
+- **Template Marketplace:** Sell premium revenue playbooks (e.g., enterprise renewal cockpit, self-serve trial launcher) as add-on blueprints.
+- **Managed Services:** Provide done-for-you GTM setup, analytics wiring, or CRO audits using the generated environments.
+- **Usage-Based Billing:** Track generated apps, preview hours, and published deployments to bill agencies or franchised partners fairly.
+
+## Implementation Highlights
+1. **Agent Mode (Revenue):** Adds specialized prompting so blueprint generation prioritizes monetization flows, lifecycle automation, and data instrumentation.
+2. **Home Experience:** Guides users toward revenue-focused prompts and highlights packaged outcomes for pricing, activation, and expansion.
+3. **Template Selection:** Introduces the `Revenue Enablement` use case so the orchestration layer chooses dashboards or SaaS marketing templates that align with revenue goals.
+4. **Blueprint Enhancements:** Revenue directive injects pricing tiers, CRM hooks, analytics dashboards, and lifecycle journeys into every plan.
+5. **Sample Prompts:** Provide actionable ideas that map to high-value GTM scenarios (enterprise pricing lab, success war room, partner revenue hub).
+
+## Monetization Rollout
+1. **Private Beta:** Invite five CRO or RevOps teams, co-build playbooks, and capture detailed case studies.
+2. **Pricing Strategy:** Start with a base platform fee plus usage metering (generated apps + deployments). Upsell advanced analytics connectors and template bundles.
+3. **Partnership Motion:** Enable agencies to white-label Revenue Mode with co-branded templates and revenue share incentives.
+4. **Growth Loop:** Capture telemetry from generated apps (with consent) to feed anonymized benchmarks back into onboarding and cross-sell nudges.
+
+## Success Metrics
+- Time-to-launch for monetization experiments drops from weeks to hours.
+- Net new ARR or pipeline influenced per generated experience.
+- Active templates per customer and template marketplace GMV.
+- Expansion revenue driven by premium connectors, analytics packs, or concierge deployment services.
+
+## Next Steps
+- Productize quick-start dashboards for pricing, lifecycle, and partner revenue scenarios.
+- Package marketing site updates highlighting Revenue Mode.
+- Launch webinar/workshop series teaching “Ship a pricing lab in 30 minutes with VibeSDK”.
+- Build integration kits for Stripe Billing, Salesforce, HubSpot, and customer data platforms.
+

--- a/samplePrompts.md
+++ b/samplePrompts.md
@@ -1,3 +1,15 @@
+Design a self-serve enterprise pricing lab that supports plan simulations, ROI calculators, persona-specific onboarding flows, and exports enriched leads to HubSpot and Salesforce.
+
+Create a multi-tenant customer success war room with health scoring dashboards, renewal playbooks, upsell opportunity tracking, and automated outreach sequences.
+
+Build a partner revenue command center that handles co-marketing asset distribution, deal registration, MDF tracking, and pipeline attribution with granular analytics.
+
+Design a virtual-first clinic operations cockpit that manages digital intake, symptom triage, clinician scheduling, HIPAA-compliant messaging, and automated care-plan nudges connected to our Athenahealth instance.
+
+Create a population health surveillance dashboard that ingests FHIR data, flags rising-risk cohorts, orchestrates outreach cadences, and tracks reimbursement-eligible RPM/CCM enrollments with payer-specific workflows.
+
+Build a CareOps marketplace where specialists can publish virtual programs, manage licensure compliance, handle claims/billing, and deliver telehealth sessions with secure document exchange and outcome reporting.
+
 Please build a chatgpt clone for me with a beautiful UI, sidebar, ability to save and retrieve previous conversations, choose between various models etc. It should be able to use tools. Use Cloudflare agents to build it
 
 Build a game where I see a map with circles on cities. Each city is a cloudflare datacenter. The map shows with data centres highlighted for 20 seconds, and after that, we show grayed out circles in multiple regions. The user's goal is to remember and click as many regions as they can in 20 seconds and get points based on that

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -160,7 +160,7 @@ export type {
 } from 'worker/agents/inferutils/config.types';
 
 export type { RateLimitError } from "worker/services/rate-limit/errors";
-export type { AgentPreviewResponse, CodeGenArgs } from 'worker/api/controllers/agent/types';
+export type { AgentPreviewResponse, CodeGenArgs, AgentMode } from 'worker/api/controllers/agent/types';
 export type { RateLimitErrorResponse } from 'worker/api/responses';
 export { RateLimitExceededError, SecurityError, SecurityErrorType } from 'shared/types/errors';
 

--- a/src/components/agent-mode-display.tsx
+++ b/src/components/agent-mode-display.tsx
@@ -1,4 +1,4 @@
-import { Zap } from 'lucide-react';
+import { Zap, Coins, Stethoscope } from 'lucide-react';
 import { type AgentMode } from './agent-mode-toggle';
 
 interface AgentModeDisplayProps {
@@ -12,12 +12,25 @@ export function AgentModeDisplay({
 }: AgentModeDisplayProps) {
   return (
     <div className={`flex items-center gap-1.5 px-2.5 py-1 bg-slate-50 dark:bg-slate-800/50 rounded-md border border-slate-200 dark:border-slate-700 ${className}`}>
-      {mode === 'smart' ? (
+      {mode === 'smart' && (
         <>
           <Zap className="size-2.5 text-violet-500" />
           <span className="text-xs font-medium text-violet-700 dark:text-violet-400">Smart</span>
         </>
-      ) : (
+      )}
+      {mode === 'revenue' && (
+        <>
+          <Coins className="size-2.5 text-amber-500" />
+          <span className="text-xs font-medium text-amber-700 dark:text-amber-400">Revenue</span>
+        </>
+      )}
+      {mode === 'healthcare' && (
+        <>
+          <Stethoscope className="size-2.5 text-sky-500" />
+          <span className="text-xs font-medium text-sky-700 dark:text-sky-400">CareOps</span>
+        </>
+      )}
+      {mode === 'deterministic' && (
         <>
           <div className="size-1.5 rounded-full bg-emerald-500" />
           <span className="text-xs font-medium text-emerald-700 dark:text-emerald-400">Reliable</span>

--- a/src/components/agent-mode-toggle.tsx
+++ b/src/components/agent-mode-toggle.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { Zap, Settings } from 'lucide-react';
+import { Zap, Settings, Coins, Stethoscope } from 'lucide-react';
+import type { AgentMode as ApiAgentMode } from '@/api-types';
 
-export type AgentMode = 'deterministic' | 'smart';
+export type AgentMode = ApiAgentMode;
 
 interface AgentModeToggleProps {
   value: AgentMode;
@@ -54,14 +55,48 @@ export function AgentModeToggle({ value, onChange, disabled = false, className =
             } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
           >
             <Zap className={`size-2.5 ${
-              value === 'smart' 
-                ? 'text-violet-500' 
+              value === 'smart'
+                ? 'text-violet-500'
                 : 'text-slate-400 dark:text-slate-500'
             }`} />
             Smart
           </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange('revenue')}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md transition-all duration-200 ${
+              value === 'revenue'
+                ? 'bg-white dark:bg-slate-700 shadow-sm text-amber-700 dark:text-amber-400 border border-slate-200 dark:border-slate-600'
+                : 'text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200'
+            } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+          >
+            <Coins className={`size-2.5 ${
+              value === 'revenue'
+                ? 'text-amber-500'
+                : 'text-slate-400 dark:text-slate-500'
+            }`} />
+            Revenue
+          </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange('healthcare')}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md transition-all duration-200 ${
+              value === 'healthcare'
+                ? 'bg-white dark:bg-slate-700 shadow-sm text-sky-700 dark:text-sky-400 border border-slate-200 dark:border-slate-600'
+                : 'text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200'
+            } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+          >
+            <Stethoscope className={`size-2.5 ${
+              value === 'healthcare'
+                ? 'text-sky-500'
+                : 'text-slate-400 dark:text-slate-500'
+            }`} />
+            CareOps
+          </button>
         </div>
-        
+
         {/* Tooltip */}
         {showTooltip && (
           <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 -translate-y-full pointer-events-none transition-opacity duration-200 z-50">
@@ -76,6 +111,16 @@ export function AgentModeToggle({ value, onChange, disabled = false, className =
                   <Zap className="size-3 text-violet-400" />
                   <span className="font-medium text-violet-300">Smart:</span>
                   <span className="text-slate-300">AI-orchestrated & adaptive</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Coins className="size-3 text-amber-400" />
+                  <span className="font-medium text-amber-300">Revenue:</span>
+                  <span className="text-slate-300">Monetization-focused product strategy</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Stethoscope className="size-3 text-sky-400" />
+                  <span className="font-medium text-sky-300">CareOps:</span>
+                  <span className="text-slate-300">Healthcare-grade workflows & compliance</span>
                 </div>
               </div>
               <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-2 border-r-2 border-t-2 border-transparent border-t-slate-700"></div>

--- a/src/routes/chat/chat.tsx
+++ b/src/routes/chat/chat.tsx
@@ -27,6 +27,7 @@ import { useFileContentStream } from './hooks/use-file-content-stream';
 import { logger } from '@/utils/logger';
 import { useApp } from '@/hooks/use-app';
 import { AgentModeDisplay } from '@/components/agent-mode-display';
+import type { AgentMode } from '@/components/agent-mode-toggle';
 import { useGitHubExport } from '@/hooks/use-github-export';
 import { GitHubExportModal } from '@/components/github-export-modal';
 import { ModelConfigInfo } from './components/model-config-info';
@@ -35,9 +36,12 @@ import { useAutoScroll } from '@/hooks/use-auto-scroll';
 export default function Chat() {
 	const { chatId: urlChatId } = useParams();
 
-	const [searchParams] = useSearchParams();
-	const userQuery = searchParams.get('query');
-	const agentMode = searchParams.get('agentMode') || 'deterministic';
+        const [searchParams] = useSearchParams();
+        const userQuery = searchParams.get('query');
+        const agentModeParam = searchParams.get('agentMode');
+        const isAgentMode = (value: string | null): value is AgentMode =>
+                value === 'deterministic' || value === 'smart' || value === 'revenue' || value === 'healthcare';
+        const agentMode: AgentMode = isAgentMode(agentModeParam) ? agentModeParam : 'deterministic';
 
 	// Load existing app data if chatId is provided
 	const { app, loading: appLoading } = useApp(urlChatId);
@@ -113,12 +117,12 @@ export default function Chat() {
 		shouldRefreshPreview,
 		// Preview deployment state
 		isPreviewDeploying,
-	} = useChat({
-		chatId: urlChatId,
-		query: userQuery,
-		agentMode: agentMode as 'deterministic' | 'smart',
-		onDebugMessage: addDebugMessage,
-	});
+        } = useChat({
+                chatId: urlChatId,
+                query: userQuery,
+                agentMode,
+                onDebugMessage: addDebugMessage,
+        });
 
 	// GitHub export functionality - use urlChatId directly from URL params
 	const githubExport = useGitHubExport(websocket, urlChatId);
@@ -488,13 +492,7 @@ export default function Chat() {
 									{import.meta.env
 										.VITE_AGENT_MODE_ENABLED && (
 										<div className="flex justify-between items-center py-2 border-b border-border-primary/50 mb-4">
-											<AgentModeDisplay
-												mode={
-													agentMode as
-														| 'deterministic'
-														| 'smart'
-												}
-											/>
+                                                                                        <AgentModeDisplay mode={agentMode} />
 										</div>
 									)}
 								</>

--- a/src/routes/chat/hooks/use-chat.ts
+++ b/src/routes/chat/hooks/use-chat.ts
@@ -2,9 +2,9 @@ import { WebSocket } from 'partysocket';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
     RateLimitExceededError,
-	type BlueprintType,
-	type WebSocketMessage,
-	type CodeFixEdits} from '@/api-types';
+        type BlueprintType,
+        type WebSocketMessage,
+        type CodeFixEdits} from '@/api-types';
 import {
 	createRepairingJSONParser,
 	ndjsonStream,
@@ -18,6 +18,7 @@ import { isConversationalMessage, addOrUpdateMessage, createUserMessage, handleR
 import { sendWebSocketMessage } from '../utils/websocket-helpers';
 import { initialStages as defaultStages, updateStage as updateStageHelper } from '../utils/project-stage-helpers';
 import type { ProjectStage } from '../utils/project-stage-helpers';
+import type { AgentMode } from '@/components/agent-mode-toggle';
 
 export interface FileType {
 	filePath: string;
@@ -45,15 +46,15 @@ export interface PhaseTimelineItem {
 }
 
 export function useChat({
-	chatId: urlChatId,
-	query: userQuery,
-	agentMode = 'deterministic',
-	onDebugMessage,
-	onTerminalMessage,
+        chatId: urlChatId,
+        query: userQuery,
+        agentMode = 'deterministic',
+        onDebugMessage,
+        onTerminalMessage,
 }: {
-	chatId?: string;
-	query: string | null;
-	agentMode?: 'deterministic' | 'smart';
+        chatId?: string;
+        query: string | null;
+        agentMode?: AgentMode;
 	onDebugMessage?: (type: 'error' | 'warning' | 'info' | 'websocket', message: string, details?: string, source?: string, messageType?: string, rawMessage?: unknown) => void;
 	onTerminalMessage?: (log: { id: string; content: string; type: 'command' | 'stdout' | 'stderr' | 'info' | 'error' | 'warn' | 'debug'; timestamp: number; source?: string }) => void;
 }) {
@@ -100,7 +101,7 @@ export function useChat({
 	const [isPreviewDeploying, setIsPreviewDeploying] = useState(false);
 	
 	// Redeployment state - tracks when redeploy button should be enabled
-	const [isRedeployReady, setIsRedeployReady] = useState(false);
+        const [isRedeployReady, setIsRedeployReady] = useState(false);
 	// const [lastDeploymentPhaseCount, setLastDeploymentPhaseCount] = useState(0);
 	const [isGenerationPaused, setIsGenerationPaused] = useState(false);
 	const [isGenerating, setIsGenerating] = useState(false);

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -2,26 +2,225 @@ import { useRef, useState, useEffect, useMemo } from 'react';
 import { ArrowRight } from 'react-feather';
 import { useNavigate } from 'react-router';
 import {
-	AgentModeToggle,
-	type AgentMode,
+        type LucideIcon,
+        LineChart,
+        CreditCard,
+        Target,
+        Users,
+        ShieldCheck,
+        HeartPulse,
+        ClipboardList,
+        Stethoscope,
+        Gauge,
+        Workflow,
+        Cpu
+} from 'lucide-react';
+import {
+        AgentModeToggle,
+        type AgentMode,
 } from '../components/agent-mode-toggle';
 import { useAuthGuard } from '../hooks/useAuthGuard';
 
 export default function Home() {
 	const navigate = useNavigate();
 	const { requireAuth } = useAuthGuard();
-	const textareaRef = useRef<HTMLTextAreaElement>(null);
-	const [agentMode, setAgentMode] = useState<AgentMode>('deterministic');
-	
-	
-	const placeholderPhrases = useMemo(() => [
-		"todo list app",
-		"F1 fantasy game",
-		"personal finance tracker"
-	], []);
-	const [currentPlaceholderPhraseIndex, setCurrentPlaceholderPhraseIndex] = useState(0);
-	const [currentPlaceholderText, setCurrentPlaceholderText] = useState("");
-	const [isPlaceholderTyping, setIsPlaceholderTyping] = useState(true);
+        const textareaRef = useRef<HTMLTextAreaElement>(null);
+        const MODE_MARKETING: Record<AgentMode, {
+                heroTitle: string;
+                heroSubtitle: string;
+                placeholders: string[];
+                features: Array<{
+                        title: string;
+                        description: string;
+                        icon: LucideIcon;
+                        badgeClass: string;
+                        iconClass: string;
+                }>;
+        }> = useMemo(() => ({
+                deterministic: {
+                        heroTitle: 'What production system should we ship today?',
+                        heroSubtitle:
+                                'Describe the workflow you need and Orange Build will deliver a phase-planned, reviewable app that ships straight to Cloudflare with deterministic quality gates.',
+                        placeholders: [
+                                'governance dashboard with audit-ready exports',
+                                'multi-stage devops release coordinator',
+                                'enterprise knowledge base with approval queue',
+                        ],
+                        features: [
+                                {
+                                        title: 'Deterministic delivery',
+                                        description:
+                                                'Structured generation, phase checkpoints, and reproducible builds keep compliance teams confident every release matches the spec.',
+                                        icon: ShieldCheck,
+                                        badgeClass: 'rounded-xl bg-emerald-500/10 text-emerald-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Phase visibility',
+                                        description:
+                                                'Granular stage tracking and blueprint clarity ensure stakeholders know exactly what ships in each iteration.',
+                                        icon: ClipboardList,
+                                        badgeClass: 'rounded-xl bg-sky-500/10 text-sky-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Operational resilience',
+                                        description:
+                                                'Automatic static analysis, runtime validation, and code fix flows deliver audit-friendly apps without regression surprises.',
+                                        icon: Users,
+                                        badgeClass: 'rounded-xl bg-slate-500/10 text-slate-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Cloudflare-native deployment',
+                                        description:
+                                                'Deploy instantly to Workers, Durable Objects, KV, and D1 with production-ready configs wired into every scaffold.',
+                                        icon: Target,
+                                        badgeClass: 'rounded-xl bg-purple-500/10 text-purple-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                        ],
+                },
+                smart: {
+                        heroTitle: 'What adaptive AI product should we orchestrate?',
+                        heroSubtitle:
+                                'Ask for the outcome and Smart Mode dynamically plans, converses, and iterates with you—shipping polished experiences that learn from every prompt.',
+                        placeholders: [
+                                'multi-tenant analytics workspace with AI insights',
+                                'onboarding concierge that adapts per persona',
+                                'developer portal with real-time guidance copilot',
+                        ],
+                        features: [
+                                {
+                                        title: 'Adaptive orchestration',
+                                        description:
+                                                'Multi-agent planning adjusts blueprints as requirements evolve, keeping complex builds aligned without manual wrangling.',
+                                        icon: Workflow,
+                                        badgeClass: 'rounded-xl bg-violet-500/10 text-violet-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Reasoning-first UX',
+                                        description:
+                                                'Smart responses explain decisions, outline trade-offs, and surface follow-up actions so teams stay in the loop.',
+                                        icon: Gauge,
+                                        badgeClass: 'rounded-xl bg-amber-500/10 text-amber-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Continuous learning',
+                                        description:
+                                                'Conversation memory, blueprint diffs, and telemetry keep refinements grounded in prior context.',
+                                        icon: Cpu,
+                                        badgeClass: 'rounded-xl bg-cyan-500/10 text-cyan-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Instant deployment',
+                                        description:
+                                                'Smart Mode manages preview builds and redeployments so you can validate changes in minutes.',
+                                        icon: Target,
+                                        badgeClass: 'rounded-xl bg-fuchsia-500/10 text-fuchsia-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                        ],
+                },
+                revenue: {
+                        heroTitle: 'What revenue engine should we build today?',
+                        heroSubtitle:
+                                'Describe the monetization experience you need—VibeSDK will orchestrate a pricing playground, conversion funnel, and analytics-ready web app that ships straight to Cloudflare.',
+                        placeholders: [
+                                'self-serve pricing lab for enterprise buyers',
+                                'sales-assisted trial hub with product analytics',
+                                'partner revenue cockpit with upsell workflows',
+                        ],
+                        features: [
+                                {
+                                        title: 'Monetization-first templates',
+                                        description:
+                                                'Automatically scaffold pricing pages, upgrade flows, trial gating, and compliant checkout touchpoints tuned for ARR growth.',
+                                        icon: CreditCard,
+                                        badgeClass: 'rounded-xl bg-amber-500/10 text-amber-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Revenue intelligence baked in',
+                                        description:
+                                                'Blueprints include attribution dashboards, funnel analytics, and lifecycle instrumentation ready for RevOps teams.',
+                                        icon: LineChart,
+                                        badgeClass: 'rounded-xl bg-sky-500/10 text-sky-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Lifecycle activation journeys',
+                                        description:
+                                                'Onboarding tours, success workspaces, and partner enablement portals arrive pre-wired for expansion and renewals.',
+                                        icon: Users,
+                                        badgeClass: 'rounded-xl bg-emerald-500/10 text-emerald-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Packaging experiments on-demand',
+                                        description:
+                                                'Launch segmented GTM experiments—usage tiers, localized offers, paywall tests—directly from the generated admin controls.',
+                                        icon: Target,
+                                        badgeClass: 'rounded-xl bg-fuchsia-500/10 text-fuchsia-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                        ],
+                },
+                healthcare: {
+                        heroTitle: 'Which care delivery workflow should we automate next?',
+                        heroSubtitle:
+                                'Sketch the patient or clinician journey and CareOps Mode assembles HIPAA-ready intake, scheduling, triage, and follow-up systems with compliant data handling baked in.',
+                        placeholders: [
+                                'virtual-first clinic intake and triage hub',
+                                'population health dashboard with risk alerts',
+                                'care team command center with secure messaging',
+                        ],
+                        features: [
+                                {
+                                        title: 'Regulatory-grade scaffolding',
+                                        description:
+                                                'Consent capture, PHI-safe storage patterns, audit trails, and role-based controls are specified in every blueprint to protect patient trust.',
+                                        icon: ShieldCheck,
+                                        badgeClass: 'rounded-xl bg-sky-500/10 text-sky-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'End-to-end patient journeys',
+                                        description:
+                                                'Automate intake, triage, care plan management, and follow-ups with multilingual, accessible experiences for every population.',
+                                        icon: HeartPulse,
+                                        badgeClass: 'rounded-xl bg-rose-500/10 text-rose-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'Connected clinical stack',
+                                        description:
+                                                'Blueprints detail integrations for EHR/FHIR sync, telehealth, secure messaging, claims, and medical devices with schema callouts.',
+                                        icon: Stethoscope,
+                                        badgeClass: 'rounded-xl bg-indigo-500/10 text-indigo-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                                {
+                                        title: 'CareOps monetization levers',
+                                        description:
+                                                'Design reimbursable RPM/CCM programs, employer and payer portals, or premium concierge tiers to unlock new revenue lines.',
+                                        icon: LineChart,
+                                        badgeClass: 'rounded-xl bg-emerald-500/10 text-emerald-500',
+                                        iconClass: 'h-5 w-5',
+                                },
+                        ],
+                },
+        }), []);
+
+        const [agentMode, setAgentMode] = useState<AgentMode>('healthcare');
+        const modeConfig = MODE_MARKETING[agentMode];
+        const placeholders = modeConfig.placeholders;
+        const [currentPlaceholderPhraseIndex, setCurrentPlaceholderPhraseIndex] = useState(0);
+        const [currentPlaceholderText, setCurrentPlaceholderText] = useState("");
+        const [isPlaceholderTyping, setIsPlaceholderTyping] = useState(true);
 
 	const handleCreateApp = (query: string, mode: AgentMode) => {
 		const encodedQuery = encodeURIComponent(query);
@@ -53,13 +252,22 @@ export default function Home() {
 		}
 	};
 
-	useEffect(() => {
-		adjustTextareaHeight();
-	}, []);
-	
-	// Typewriter effect
-	useEffect(() => {
-		const currentPhrase = placeholderPhrases[currentPlaceholderPhraseIndex];
+        useEffect(() => {
+                adjustTextareaHeight();
+        }, []);
+
+        useEffect(() => {
+                setCurrentPlaceholderPhraseIndex(0);
+                setCurrentPlaceholderText('');
+                setIsPlaceholderTyping(true);
+        }, [agentMode]);
+
+        // Typewriter effect
+        useEffect(() => {
+                if (placeholders.length === 0) {
+                        return;
+                }
+                const currentPhrase = placeholders[currentPlaceholderPhraseIndex % placeholders.length];
 		
 		if (isPlaceholderTyping) {
 			if (currentPlaceholderText.length < currentPhrase.length) {
@@ -82,11 +290,11 @@ export default function Home() {
 				return () => clearTimeout(timeout);
 			} else {
 				// Move to next phrase
-				setCurrentPlaceholderPhraseIndex((prev) => (prev + 1) % placeholderPhrases.length);
-				setIsPlaceholderTyping(true);
-			}
-		}
-	}, [currentPlaceholderText, currentPlaceholderPhraseIndex, isPlaceholderTyping, placeholderPhrases]);
+                                setCurrentPlaceholderPhraseIndex((prev) => (prev + 1) % placeholders.length);
+                                setIsPlaceholderTyping(true);
+                        }
+                }
+        }, [currentPlaceholderText, currentPlaceholderPhraseIndex, isPlaceholderTyping, placeholders]);
 	return (
 		<div className="flex flex-col items-center size-full">
 			<div className="rounded-md mt-46 w-full max-w-2xl overflow-hidden">
@@ -116,9 +324,12 @@ export default function Home() {
 					</svg>
 				</div>
 				<div className="px-6 p-8 flex flex-col items-center z-10">
-					<h1 className="text-shadow-sm text-shadow-red-200 dark:text-shadow-red-900 text-accent font-medium leading-[1.1] tracking-tight text-6xl w-full mb-4 bg-clip-text bg-gradient-to-r from-text-primary to-text-primary/90">
-						What should we build today?
-					</h1>
+                                        <h1 className="text-shadow-sm text-shadow-red-200 dark:text-shadow-red-900 text-accent font-medium leading-[1.1] tracking-tight text-6xl w-full mb-4 bg-clip-text bg-gradient-to-r from-text-primary to-text-primary/90">
+                                                {modeConfig.heroTitle}
+                                        </h1>
+                                        <p className="text-center text-text-primary/70 max-w-2xl mb-6">
+                                                {modeConfig.heroSubtitle}
+                                        </p>
 
 					<form
 						method="POST"
@@ -166,7 +377,24 @@ export default function Home() {
 						</div>
 					</form>
 				</div>
-			</div>
-		</div>
-	);
+                        </div>
+                        <div className="mt-12 grid w-full max-w-4xl gap-4 md:grid-cols-2">
+                                {modeConfig.features.map((feature) => (
+                                        <div key={feature.title} className="rounded-2xl border border-accent/20 bg-bg-4/60 p-6 backdrop-blur">
+                                                <div className="mb-4 flex items-center gap-3">
+                                                        <div className={`${feature.badgeClass} p-2`}>
+                                                                <feature.icon className={feature.iconClass} />
+                                                        </div>
+                                                        <h2 className="text-lg font-semibold text-text-primary">
+                                                                {feature.title}
+                                                        </h2>
+                                                </div>
+                                                <p className="text-sm text-text-primary/70">
+                                                        {feature.description}
+                                                </p>
+                                        </div>
+                                ))}
+                        </div>
+                </div>
+        );
 }

--- a/worker/agents/core/simpleGeneratorAgent.ts
+++ b/worker/agents/core/simpleGeneratorAgent.ts
@@ -9,7 +9,7 @@ import {
 } from '../schemas';
 import { GitHubPushRequest, PreviewType, StaticAnalysisResponse, TemplateDetails } from '../../services/sandbox/sandboxTypes';
 import {  GitHubExportResult } from '../../services/github/types';
-import { CodeGenState, CurrentDevState, MAX_PHASES, FileState } from './state';
+import { CodeGenState, CurrentDevState, MAX_PHASES, FileState, AgentMode } from './state';
 import { AllIssues, AgentSummary, ScreenshotData, AgentInitArgs } from './types';
 import { WebSocketMessageResponses } from '../constants';
 import { broadcastToConnections, handleWebSocketClose, handleWebSocketMessage } from './websocket';
@@ -261,7 +261,7 @@ export class SimpleCodeGeneratorAgent extends Agent<Env, CodeGenState> {
      */
     async initialize(
         initArgs: AgentInitArgs,
-        ..._args: unknown[]
+        agentMode: AgentMode = 'deterministic'
     ): Promise<CodeGenState> {
 
         const { query, language, frameworks, hostname, inferenceContext, templateInfo, sandboxSessionId } = initArgs;
@@ -277,6 +277,7 @@ export class SimpleCodeGeneratorAgent extends Agent<Env, CodeGenState> {
             frameworks: frameworks!,
             templateDetails: templateInfo.templateDetails,
             templateMetaInfo: templateInfo.selection,
+            agentMode,
             stream: {
                 chunk_size: 256,
                 onChunk: (chunk) => {
@@ -291,6 +292,7 @@ export class SimpleCodeGeneratorAgent extends Agent<Env, CodeGenState> {
         
         this.setState({
             ...this.initialState,
+            agentMode,
             query,
             blueprint,
             templateDetails: templateInfo.templateDetails,

--- a/worker/agents/core/smartGeneratorAgent.ts
+++ b/worker/agents/core/smartGeneratorAgent.ts
@@ -1,5 +1,5 @@
 import { SimpleCodeGeneratorAgent } from "./simpleGeneratorAgent";
-import { CodeGenState } from "./state";
+import { CodeGenState, AgentMode } from "./state";
 import { AgentInitArgs } from "./types";
 
 /**
@@ -15,7 +15,7 @@ export class SmartCodeGeneratorAgent extends SimpleCodeGeneratorAgent {
      */
     async initialize(
         initArgs: AgentInitArgs,
-        agentMode: 'deterministic' | 'smart'
+        agentMode: AgentMode
     ): Promise<CodeGenState> {
         this.logger().info('🧠 Initializing SmartCodeGeneratorAgent with enhanced AI orchestration', {
             queryLength: initArgs.query.length,
@@ -23,15 +23,14 @@ export class SmartCodeGeneratorAgent extends SimpleCodeGeneratorAgent {
         });
 
         // Call the parent initialization
-        return await super.initialize(initArgs);
+        return await super.initialize(initArgs, agentMode);
     }
 
     async generateAllFiles(reviewCycles: number = 10): Promise<void> {
-        if (this.state.agentMode === 'deterministic') {
-            return super.generateAllFiles(reviewCycles);
-        } else {
+        if (this.state.agentMode === 'smart') {
             return this.builderLoop();
         }
+        return super.generateAllFiles(reviewCycles);
     }
 
     async builderLoop() {

--- a/worker/agents/core/state.ts
+++ b/worker/agents/core/state.ts
@@ -1,10 +1,15 @@
-import type { Blueprint, ClientReportedErrorType, PhaseConceptType ,
+import type {
+    Blueprint,
+    ClientReportedErrorType,
+    PhaseConceptType,
     FileOutputType,
 } from '../schemas';
 import type { TemplateDetails } from '../../services/sandbox/sandboxTypes';
 // import type { ScreenshotData } from './types';
 import type { ConversationMessage } from '../inferutils/common';
 import type { InferenceContext } from '../inferutils/config.types';
+
+export type AgentMode = 'deterministic' | 'smart' | 'revenue' | 'healthcare';
 
 export interface FileState extends FileOutputType {
     last_hash: string;
@@ -44,7 +49,7 @@ export interface CodeGenState {
     // latestScreenshot?: ScreenshotData; // Store captured screenshot
     shouldBeGenerating: boolean; // Persistent flag indicating generation should be active
     mvpGenerated: boolean;
-    agentMode: 'deterministic' | 'smart';
+    agentMode: AgentMode;
     sessionId: string;
     hostname: string;
     phasesCounter: number;

--- a/worker/agents/planning/blueprint.ts
+++ b/worker/agents/planning/blueprint.ts
@@ -5,6 +5,7 @@ import { Blueprint, BlueprintSchema, TemplateSelection } from '../schemas';
 import { createLogger } from '../../logger';
 import { createSystemMessage, createUserMessage } from '../inferutils/common';
 import { InferenceContext } from '../inferutils/config.types';
+import type { AgentMode } from '../core/state';
 
 const logger = createLogger('Blueprint');
 
@@ -131,6 +132,35 @@ Preinstalled dependencies:
 {{dependencies}}
 </STARTING TEMPLATE>`;
 
+const REVENUE_MODE_DIRECTIVE = `
+<MODE>
+    ## Revenue Engine Charter
+    • Treat this build as a revenue-critical application. Translate vague prompts into comprehensive monetization systems that cover pricing experimentation, lead capture, onboarding, retention, and expansion.
+    • Blueprints MUST detail recurring revenue mechanics: pricing tiers, plan upgrade paths, trial or credit workflows, billing compliance messaging, and revenue assurance safeguards.
+    • Require analytics-ready instrumentation: conversion funnels, CAC/LTV dashboards, cohort tracking, and experiment toggles with clear success metrics.
+    • Specify integrations for CRM/sales handoff, subscription billing, customer success, product analytics, and marketing automation with explicit data contracts.
+    • Map lifecycle automation including onboarding tours, milestone nudges, renewal/expansion playbooks, partner enablement, and account health scoring.
+    • Provide messaging frameworks that include differentiated value props, objection handling, proof assets, and personalization hooks for each buyer segment.
+    • Highlight how the experience supports GTM experimentation (A/B paywall variants, localized offers, usage-based packaging) across self-serve and sales-assisted journeys.
+</MODE>`;
+
+const HEALTHCARE_MODE_DIRECTIVE = `
+<MODE>
+    ## CareOps Delivery Charter
+    • Assume the experience is mission-critical for clinical operations or patient engagement. Translate prompts into workflows that reduce care team toil while elevating patient outcomes.
+    • Require explicit guardrails for HIPAA compliance, consent capture, PHI handling, audit trails, and role-based access across staff, clinicians, and administrators.
+    • Specify integrations with EHR/EMR systems (HL7/FHIR), telehealth platforms, secure messaging, claims/billing, and medical device data—with schemas and sync cadences.
+    • Design patient journeys end-to-end: intake, triage, scheduling, care plan management, follow-up nudges, and population health analytics. Include multilingual and accessibility considerations.
+    • Provide clinical safety nets such as escalation paths, symptom checking decision trees, verification checkpoints, and documentation templates aligned to regulatory codes.
+    • Map monetization levers suited for care delivery: reimbursable programs (RPM/CCM), membership tiers, employer contracts, marketplace listings, or premium concierge add-ons.
+    • Deliver operational intelligence dashboards for throughput, readmission risk, satisfaction, and reimbursement rates with alerts for SLA breaches or compliance anomalies.
+</MODE>`;
+
+const MODE_DIRECTIVES: Partial<Record<AgentMode, string>> = {
+    revenue: REVENUE_MODE_DIRECTIVE,
+    healthcare: HEALTHCARE_MODE_DIRECTIVE,
+};
+
 // const USER_PROMPT = ``;
 
 // const OPTIMIZED_USER_PROMPT = `Developer: # Role
@@ -231,6 +261,7 @@ export interface BlueprintGenerationArgs {
     // Add optional template info
     templateDetails: TemplateDetails;
     templateMetaInfo: TemplateSelection;
+    agentMode: AgentMode;
     stream?: {
         chunk_size: number;
         onChunk: (chunk: string) => void;
@@ -241,7 +272,7 @@ export interface BlueprintGenerationArgs {
  * Generate a blueprint for the application based on user prompt
  */
 // Update function signature and system prompt
-export async function generateBlueprint({ env, inferenceContext, query, language, frameworks, templateDetails, templateMetaInfo, stream }: BlueprintGenerationArgs): Promise<Blueprint> {
+export async function generateBlueprint({ env, inferenceContext, query, language, frameworks, templateDetails, templateMetaInfo, agentMode, stream }: BlueprintGenerationArgs): Promise<Blueprint> {
     try {
         logger.info("Generating application blueprint", { query, queryLength: query.length });
         logger.info(templateDetails ? `Using template: ${templateDetails.name}` : "Not using a template.");
@@ -250,7 +281,10 @@ export async function generateBlueprint({ env, inferenceContext, query, language
         // Build the SYSTEM prompt for blueprint generation
         // ---------------------------------------------------------------------------
 
-        const systemPrompt = createSystemMessage(generalSystemPromptBuilder(SYSTEM_PROMPT, {
+        const modeDirective = agentMode ? MODE_DIRECTIVES[agentMode] : undefined;
+        const promptBase = modeDirective ? `${SYSTEM_PROMPT}\n${modeDirective}` : SYSTEM_PROMPT;
+
+        const systemPrompt = createSystemMessage(generalSystemPromptBuilder(promptBase, {
             query,
             templateDetails,
             frameworks,

--- a/worker/agents/planning/templateSelector.ts
+++ b/worker/agents/planning/templateSelector.ts
@@ -73,6 +73,14 @@ Reasoning: "Social template provides user interactions, content sharing, and com
 - **Illustrative**: Rich graphics and visual storytelling
 - **Kid_Playful**: Colorful, fun, child-friendly interfaces
 
+## REVENUE ENABLEMENT FLAG:
+- When the user emphasises monetization, pricing, revenue operations, GTM funnels, or customer lifecycle tooling, set useCase to 'Revenue Enablement'.
+- Prefer templates suited for dashboards or SaaS marketing surfaces when Revenue Enablement is chosen.
+
+## HEALTHCARE OPERATIONS FLAG:
+- When the user focuses on patients, clinicians, care coordination, HIPAA/compliance, scheduling, triage, telehealth, or population health, set useCase to 'Healthcare Operations'.
+- Prefer templates that support secure portals, operational dashboards, or workflow management when Healthcare Operations is selected.
+
 ## RULES:
 - ALWAYS select a template (never return null)
 - Ignore misleading template names - analyze actual features

--- a/worker/agents/prompts.ts
+++ b/worker/agents/prompts.ts
@@ -1087,11 +1087,35 @@ const ECOMM_INSTRUCTIONS = (): string => `
 const DASHBOARD_INSTRUCTIONS = (): string => `
 ** If applicable to user query group Related Controls and Forms into Well-Labeled Cards / Panels
 ** If applicable to user query offer Quick Actions / Shortcuts for Common Tasks
-** If user asked for analytics/visualizations/statistics - Show sparklines, mini line/bar charts, or simple pie indicators for trends 
+** If user asked for analytics/visualizations/statistics - Show sparklines, mini line/bar charts, or simple pie indicators for trends
 ** If user asked for analytics/visualizations/statistics - Maybe show key metrics in modular cards
 ** If applicable to user query make It Interactive and Contextual (Filters, Search, Pagination)
 ** If applicable to user query add a sidebar and or tabs
 ** Dashboard should be information dense.
+`;
+
+const REVENUE_ENABLEMENT_INSTRUCTIONS = (style: TemplateSelection['styleSelection']): string => `
+** Build a monetization-centric experience. Include pricing tier cards, plan comparison tables, ROI calculators, and clear upgrade CTAs.
+** Provide conversion funnels, experiment toggles, retention health indicators, and lifecycle automation panels. Instrument the UI for analytics events.
+** Include sections for sales-assisted workflows (demo booking, contract review), customer success playbooks, and partner/agency enablement if relevant.
+** Call out integration surfaces for CRM, billing, product analytics, and marketing automation with explicit data schema guidance.
+** Ensure copy blocks highlight value propositions, proof assets, objection handling, and tailored messaging per buyer persona.
+** Support localization and packaging experiments with configurable modules or toggles.
+
+Use the following artistic style to maintain polish:
+${getStyleInstructions(style)}
+`;
+
+const HEALTHCARE_OPERATIONS_INSTRUCTIONS = (style: TemplateSelection['styleSelection']): string => `
+** Design for regulated care delivery. Include consent capture, role-based access, audit trails, and PHI-safe data handling patterns throughout the UI.
+** Map patient and clinician journeys end-to-end—intake, triage, visit prep, care plan tracking, follow-ups, and escalation—with clear status indicators.
+** Provide integrations or data exchange modules for EHR/FHIR, telehealth, secure messaging, insurance eligibility, and medical devices with schema notes.
+** Surface operational intelligence dashboards (capacity, readmission risk, satisfaction, reimbursement) and alerting panels for compliance or SLA breaches.
+** Offer monetization pathways like reimbursable virtual care programs, employer or payer portals, premium concierge tiers, or marketplace add-ons.
+** Prioritize accessibility, localization, and trust signals (certifications, clinician bios, outcome metrics) to build confidence across patient populations.
+
+Use the following artistic style to maintain polish:
+${getStyleInstructions(style)}
 `;
 
 export const getUsecaseSpecificInstructions = (selectedTemplate: TemplateSelection): string => {
@@ -1102,6 +1126,10 @@ export const getUsecaseSpecificInstructions = (selectedTemplate: TemplateSelecti
             return ECOMM_INSTRUCTIONS();
         case 'Dashboard':
             return DASHBOARD_INSTRUCTIONS();
+        case 'Revenue Enablement':
+            return REVENUE_ENABLEMENT_INSTRUCTIONS(selectedTemplate.styleSelection);
+        case 'Healthcare Operations':
+            return HEALTHCARE_OPERATIONS_INSTRUCTIONS(selectedTemplate.styleSelection);
         default:
             return `Use the following artistic style:
             ${getStyleInstructions(selectedTemplate.styleSelection)}`;

--- a/worker/agents/schemas.ts
+++ b/worker/agents/schemas.ts
@@ -4,7 +4,7 @@ import z from 'zod';
 export const TemplateSelectionSchema = z.object({
     selectedTemplateName: z.string().nullable().describe('The name of the most suitable template, or null if none are suitable.'),
     reasoning: z.string().describe('Brief explanation for the selection or why no template was chosen.'),
-    useCase: z.enum(['SaaS Product Website', 'Dashboard', 'Blog', 'Portfolio', 'E-Commerce', 'General', 'Other']).describe('The use case for which the template is selected, if applicable.').nullable(),
+    useCase: z.enum(['SaaS Product Website', 'Dashboard', 'Blog', 'Portfolio', 'E-Commerce', 'Revenue Enablement', 'Healthcare Operations', 'General', 'Other']).describe('The use case for which the template is selected, if applicable.').nullable(),
     complexity: z.enum(['simple', 'moderate', 'complex']).describe('The complexity of developing the project based on the the user query').nullable(),
     styleSelection: z.enum(['Minimalist Design', 'Brutalism', 'Retro', 'Illustrative', 'Kid_Playful']).describe('Pick a style relevant to the user query').nullable(),
     projectName: z.string().describe('The name of the project based on the user query'),

--- a/worker/api/controllers/agent/controller.ts
+++ b/worker/api/controllers/agent/controller.ts
@@ -4,6 +4,7 @@ import { generateId } from '../../../utils/idGenerator';
 import { CodeGenState } from '../../../agents/core/state';
 import { getAgentStub, getTemplateForQuery } from '../../../agents';
 import { AgentConnectionData, AgentPreviewResponse, CodeGenArgs } from './types';
+import type { AgentMode } from '../../../agents/core/state';
 import { ApiResponse, ControllerResponse } from '../types';
 import { RouteContext } from '../../types/route-context';
 import { ModelConfigService } from '../../../database';
@@ -123,6 +124,12 @@ export class CodingAgentController extends BaseController {
                 }
             });
 
+            const allowedAgentModes: AgentMode[] = ['deterministic', 'smart', 'revenue', 'healthcare'];
+            const requestedMode = body.agentMode;
+            const resolvedAgentMode: AgentMode = allowedAgentModes.includes(requestedMode as AgentMode)
+                ? requestedMode as AgentMode
+                : defaultCodeGenArgs.agentMode;
+
             const agentPromise = agentInstance.initialize({
                 query,
                 language: body.language || defaultCodeGenArgs.language,
@@ -134,7 +141,7 @@ export class CodingAgentController extends BaseController {
                 },
                 templateInfo: { templateDetails, selection },
                 sandboxSessionId
-            }, body.agentMode || defaultCodeGenArgs.agentMode) as Promise<CodeGenState>;
+            }, resolvedAgentMode) as Promise<CodeGenState>;
             agentPromise.then(async (_state: CodeGenState) => {
                 writer.write("terminate");
                 writer.close();

--- a/worker/api/controllers/agent/types.ts
+++ b/worker/api/controllers/agent/types.ts
@@ -1,11 +1,12 @@
 import { PreviewType } from "../../../services/sandbox/sandboxTypes";
+import type { AgentMode } from "../../../agents/core/state";
 
 export interface CodeGenArgs {
     query: string;
     language?: string;
     frameworks?: string[];
     selectedTemplate?: string;
-    agentMode: 'deterministic' | 'smart';
+    agentMode: AgentMode;
 }
 
 /**
@@ -18,4 +19,6 @@ export interface AgentConnectionData {
 
 export interface AgentPreviewResponse extends PreviewType {
 }
+
+export type { AgentMode };
     


### PR DESCRIPTION
## Summary
- introduce a CareOps healthcare agent mode with HIPAA-aware blueprint directives, template selection guidance, and use case instructions
- update the UI, prompt packs, and docs to highlight healthcare scenarios alongside existing revenue workflows, including a dedicated playbook
- expand home page marketing content so mode selection dynamically adjusts hero copy, prompts, and feature highlights for each audience

## Testing
- npm run lint *(fails: missing @eslint/js dependency because package installation is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b2a0df2c8333aff4e9e6aa5791b8